### PR TITLE
Feature: Thêm tính năng đổi phiên bản PHP cho website

### DIFF
--- a/shared/config/config.sh
+++ b/shared/config/config.sh
@@ -45,6 +45,7 @@ source "$FUNCTIONS_DIR/php_utils.sh"
 source "$FUNCTIONS_DIR/db_utils.sh"
 source "$FUNCTIONS_DIR/website_utils.sh"
 source "$FUNCTIONS_DIR/misc_utils.sh"
+source "$FUNCTIONS_DIR/nginx_utils.sh"
 # 🎨 **Màu sắc terminal**
 RED='\033[1;31m'
 GREEN='\033[1;32m'

--- a/shared/scripts/functions/menu/manage_website_menu.sh
+++ b/shared/scripts/functions/menu/manage_website_menu.sh
@@ -9,10 +9,11 @@ manage_website_menu() {
         echo -e "${GREEN}[4]${NC} 🔄 Restart Website"
         echo -e "${GREEN}[5]${NC} 📄 Xem Logs Website"
         echo -e "${GREEN}[6]${NC} 🔍 Xem Thông Tin Website"
-        echo -e "${GREEN}[7]${NC} ⬅️ Quay lại"
+        echo -e "${GREEN}[7]${NC} 🔀 Thay Đổi Phiên Bản PHP"
+        echo -e "${GREEN}[8]${NC} ⬅️ Quay lại"
         echo ""
 
-        read -p "Chọn một chức năng (1-7): " sub_choice
+        read -p "Chọn một chức năng (1-8): " sub_choice
         case $sub_choice in
             1) bash "$WEBSITE_MGMT_DIR/create-website.sh"; read -p "Nhấn Enter để tiếp tục..." ;;
             2) bash "$WEBSITE_MGMT_DIR/delete-website.sh"; read -p "Nhấn Enter để tiếp tục..." ;;
@@ -20,9 +21,10 @@ manage_website_menu() {
             4) bash "$WEBSITE_MGMT_DIR/restart-website.sh"; read -p "Nhấn Enter để tiếp tục..." ;;
             5) bash "$WEBSITE_MGMT_DIR/logs-website.sh"; read -p "Nhấn Enter để tiếp tục..." ;;
             6) bash "$WEBSITE_MGMT_DIR/view-website-info.sh"; read -p "Nhấn Enter để tiếp tục..." ;;
-            7) break ;;
+            7) bash "$WEBSITE_MGMT_DIR/website-change-php.sh"; read -p "Nhấn Enter để tiếp tục..." ;;
+            8) break ;;
             *) 
-                echo -e "${RED}⚠️ Lựa chọn không hợp lệ! Vui lòng chọn từ [1-7].${NC}"
+                echo -e "${RED}⚠️ Lựa chọn không hợp lệ! Vui lòng chọn từ [1-8].${NC}"
                 sleep 2 
                 ;;
         esac

--- a/shared/scripts/functions/network_utils.sh
+++ b/shared/scripts/functions/network_utils.sh
@@ -22,41 +22,6 @@ is_domain_resolvable() {
 
 }
 
-
-# Restart NGINX Proxy
-restart_nginx_proxy() {
-    echo -e "${YELLOW}🔄 Đang khởi động lại NGINX Proxy với docker-compose.override.yml...${NC}"
-
-    # Di chuyển vào thư mục chứa docker-compose.yml
-    cd "$NGINX_PROXY_DIR" || {
-        echo -e "${RED}❌ Lỗi: Không thể truy cập thư mục $NGINX_PROXY_DIR${NC}"
-        return 1
-    }
-
-    # Dừng tất cả container trong docker-compose.yml và override
-    echo -e "${BLUE}🛑 Đang dừng tất cả container...${NC}"
-    docker compose down
-
-    # Chờ 2 giây để đảm bảo container dừng hoàn toàn (tránh lỗi mount)
-    sleep 2
-
-    # Khởi động lại Docker Compose mà không chỉ định -f, để nó tự động load override
-    echo -e "${GREEN}🚀 Đang khởi động lại container NGINX Proxy...${NC}"
-    docker compose up -d
-
-    # Kiểm tra xem container có khởi động thành công không
-    if docker ps --format '{{.Names}}' | grep -q "^$NGINX_PROXY_CONTAINER$"; then
-        echo -e "${GREEN}✅ NGINX Proxy đã được khởi động lại thành công.${NC}"
-    else
-        echo -e "${RED}❌ Lỗi: Không thể khởi động lại NGINX Proxy.${NC}"
-    fi
-
-    # Quay về thư mục cũ (nếu cần)
-    cd - > /dev/null 2>&1
-}
-
-
-
 # Hàm kiểm tra một mạng Docker có tồn tại không
 is_network_exists() {
     local network_name="$1"

--- a/shared/scripts/functions/nginx_utils.sh
+++ b/shared/scripts/functions/nginx_utils.sh
@@ -34,3 +34,36 @@ EOF
         echo -e "${YELLOW}⚠️ Mount logs đã tồn tại: $MOUNT_LOGS${NC}"
     fi
 }
+
+
+# Restart NGINX Proxy
+restart_nginx_proxy() {
+    echo -e "${YELLOW}🔄 Đang khởi động lại NGINX Proxy với docker-compose.override.yml...${NC}"
+
+    # Di chuyển vào thư mục chứa docker-compose.yml
+    cd "$NGINX_PROXY_DIR" || {
+        echo -e "${RED}❌ Lỗi: Không thể truy cập thư mục $NGINX_PROXY_DIR${NC}"
+        return 1
+    }
+
+    # Dừng tất cả container trong docker-compose.yml và override
+    echo -e "${BLUE}🛑 Đang dừng tất cả container...${NC}"
+    docker compose down
+
+    # Chờ 2 giây để đảm bảo container dừng hoàn toàn (tránh lỗi mount)
+    sleep 2
+
+    # Khởi động lại Docker Compose mà không chỉ định -f, để nó tự động load override
+    echo -e "${GREEN}🚀 Đang khởi động lại container NGINX Proxy...${NC}"
+    docker compose up -d
+
+    # Kiểm tra xem container có khởi động thành công không
+    if docker ps --format '{{.Names}}' | grep -q "^$NGINX_PROXY_CONTAINER$"; then
+        echo -e "${GREEN}✅ NGINX Proxy đã được khởi động lại thành công.${NC}"
+    else
+        echo -e "${RED}❌ Lỗi: Không thể khởi động lại NGINX Proxy.${NC}"
+    fi
+
+    # Quay về thư mục cũ (nếu cần)
+    cd - > /dev/null 2>&1
+}

--- a/shared/scripts/website-management/website-change-php.sh
+++ b/shared/scripts/website-management/website-change-php.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# =====================================
+# 🔀 website_change_php – Thay đổi phiên bản PHP cho website
+# =====================================
+
+#!/bin/bash
+
+CONFIG_FILE="shared/config/config.sh"
+
+# Xác định đường dẫn tuyệt đối của `config.sh`
+while [ ! -f "$CONFIG_FILE" ]; do
+    CONFIG_FILE="../$CONFIG_FILE"
+    if [ "$(pwd)" = "/" ]; then
+        echo "❌ Lỗi: Không tìm thấy config.sh!" >&2
+        exit 1
+    fi
+done
+
+source "$CONFIG_FILE"
+
+
+select_website || exit 1
+
+SITE_DIR="$SITES_DIR/$SITE_NAME"
+ENV_FILE="$SITE_DIR/.env"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo -e "${RED}❌ Không tìm thấy file .env trong website ${SITE_NAME}!${NC}"
+  exit 1
+fi
+
+# Danh sách phiên bản PHP hỗ trợ
+PHP_VERSIONS=("php74" "php80" "php81" "php82")
+echo -e "${YELLOW}🔧 Chọn phiên bản PHP mới cho website ${SITE_NAME}:${NC}"
+echo ""
+echo -e "${YELLOW}⚠️ Ghi chú:${NC}"
+echo -e "${RED}- Các phiên bản PHP 7.4 trở xuống có thể KHÔNG hoạt động trên hệ điều hành ARM như:${NC}"
+echo -e "  ${CYAN}- Apple Silicon (Mac M1, M2), Raspberry Pi, hoặc máy chủ ARM64 khác${NC}"
+echo -e "  ${WHITE}  → Nếu gặp lỗi \"platform mismatch\", bạn cần sửa docker-compose.yml và thêm:${NC}"
+echo -e "     ${GREEN}platform: linux/amd64${NC}"
+
+for i in "${!PHP_VERSIONS[@]}"; do
+  echo -e "  ${GREEN}[$i]${NC} ${PHP_VERSIONS[$i]}"
+done
+
+read -p "🔹 Nhập số tương ứng: " php_index
+selected_php="${PHP_VERSIONS[$php_index]}"
+
+if [[ -z "$selected_php" ]]; then
+  echo -e "${RED}❌ Lựa chọn không hợp lệ.${NC}"
+  exit 1
+fi
+
+# Cập nhật phiên bản PHP trong file .env
+sed -i.bak "s/^PHP_VERSION=.*/PHP_VERSION=$selected_php/" "$ENV_FILE"
+
+echo -e "${GREEN}✅ Đã cập nhật phiên bản PHP thành: $selected_php${NC}"
+echo -e "${YELLOW}🔄 Đang khởi động lại website để áp dụng thay đổi...${NC}"
+
+# Dừng và xóa container PHP (không ảnh hưởng đến mariadb)
+cd "$SITE_DIR"
+docker compose stop php
+docker rm -f "${SITE_NAME}-php" 2>/dev/null || true
+
+# Khởi động lại PHP với phiên bản mới
+docker compose up -d php
+
+echo -e "${GREEN}✅ Website $SITE_NAME đã được chạy lại với PHP: $selected_php${NC}"


### PR DESCRIPTION
### ✨ Tính năng mới: Hỗ trợ thay đổi phiên bản PHP cho từng website

✅ Đã thêm một tính năng mới trong menu “Quản lý Website WordPress”:

- Cho phép người dùng **chọn và thay đổi phiên bản PHP** cho từng website WordPress đã cài đặt.

📁 Tập tin mới:
- `shared/scripts/functions/website-management/website_change_php.sh`

🧠 Tính năng nổi bật:
- Hỗ trợ các phiên bản PHP phổ biến: `php74`, `php80`, `php81`, `php82`
- Tự động cập nhật biến `PHP_VERSION` trong file `.env`
- Dừng service `php`, xóa container PHP cũ (nếu cần), và khởi động lại với phiên bản mới
- **Không ảnh hưởng đến container `mariadb` → đảm bảo an toàn dữ liệu**
- Menu hiển thị cảnh báo nếu người dùng chọn PHP 7.4 trên nền tảng ARM (Apple Silicon, Raspberry Pi...)

📋 Ghi chú sử dụng:
- Nếu gặp lỗi `"platform mismatch"` trên máy ARM (M1, M2), người dùng cần sửa `docker-compose.yml` và thêm dòng: `yaml
  platform: linux/amd64
`

🔁 Đã tích hợp vào menu [7] 🔀 Thay Đổi Phiên Bản PHP trong menu "Quản lý Website WordPress"
